### PR TITLE
Bugfix for GetNumSize

### DIFF
--- a/Curve25519/Curve25519.cs
+++ b/Curve25519/Curve25519.cs
@@ -250,7 +250,7 @@ namespace Elliptic
 
         static int GetNumSize(byte[] num, int maxSize)
         {
-            for (int i = maxSize; i >= 0; i++)
+            for (int i = maxSize; i >= 0; i--)
             {
                 if (num[i] == 0) return i + 1;
             }


### PR DESCRIPTION
GetNumSize method contains a bug (file https://github.com/hanswolff/curve25519/blob/master/Curve25519/Curve25519.cs)

Original Java method (http://code.google.com/p/curve25519-java/):

```
	private static final int numsize(byte[] x,int n) {
		while (n--!=0 && x[n]==0)
			;
		return n+1;
	}
```

The current implementation (note the counter increment):

```
       static int GetNumSize(byte[] num, int maxSize)
        {
            for (int i = maxSize; i >= 0; i++)
            {
                if (num[i] == 0) return i + 1;
            }
            return 0;
        }
```